### PR TITLE
Vim: Support project wide occurrences

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -509,14 +509,13 @@ def vim_occurrences(vimvar, project_wide):
         lcol = pos['start']['col']
         occur = { "lnum": lnum, "col": lcol + 1, "vcol": 0, "nr": nr,
                  "pattern": "", "type": "I", "valid": 1 }
-        if 'file' in pos:
-            occur["filename"] = pos['file']
-            occur["text"] = ""
-            is_current_file = (pos['file'] == cur_fname)
-        else:
-            occur["bufnr"] = bufnr
+        is_current_file = ('file' not in pos or pos['file'] == cur_fname)
+        if is_current_file:
             occur["text"] = vim.current.buffer[lnum - 1]
-            is_current_file = True
+            occur["bufnr"] = bufnr
+        else:
+            occur["text"] = ""
+            occur["filename"] = pos['file']
         vim.command("let l:tmp = " + vim_record(occur))
         vim.command("call add(%s, l:tmp)" % vimvar)
         if is_current_file and (lnum, lcol) <= (line, col): cursorpos = nr

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -488,7 +488,9 @@ function! merlin#Occurrences()
   endif
 
   call setloclist(0, l:occurrences)
-  execute ":ll! " . l:pos
+  if l:pos > 0
+    execute ":ll! " . l:pos
+  endif
   if g:merlin_display_occurrence_list
     lopen
   endif
@@ -502,7 +504,9 @@ function! merlin#OccurrencesProjectWide()
     return
   endif
   call setqflist(l:occurrences)
-  execute ":cc! " . l:pos
+  if l:pos > 0
+    execute ":cc! " . l:pos
+  endif
   if g:merlin_display_occurrence_list
     copen
   endif

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -481,7 +481,7 @@ endfunction
 function! merlin#Occurrences()
   let l:occurrences = []
   let l:pos = 0
-  MerlinPy vim.command ("let l:pos = %d" % merlin.vim_occurrences("l:occurrences"))
+  MerlinPy vim.command ("let l:pos = %d" % merlin.vim_occurrences("l:occurrences", False))
 
   if l:occurrences == []
     return
@@ -491,6 +491,20 @@ function! merlin#Occurrences()
   execute ":ll! " . l:pos
   if g:merlin_display_occurrence_list
     lopen
+  endif
+endfunction
+
+function! merlin#OccurrencesProjectWide()
+  let l:occurrences = []
+  let l:pos = 0
+  MerlinPy vim.command ("let l:pos = %d" % merlin.vim_occurrences("l:occurrences", True))
+  if l:occurrences == []
+    return
+  endif
+  call setqflist(l:occurrences)
+  execute ":cc! " . l:pos
+  if g:merlin_display_occurrence_list
+    copen
   endif
 endfunction
 
@@ -749,6 +763,8 @@ function! merlin#Register()
   command! -buffer -nargs=0 MerlinOccurrences call merlin#Occurrences()
   nmap <silent><buffer> <Plug>(MerlinSearchOccurrencesForward)  :call merlin_find#OccurrencesSearch('/')<cr>:let v:searchforward=1<cr>
   nmap <silent><buffer> <Plug>(MerlinSearchOccurrencesBackward) :call merlin_find#OccurrencesSearch('?')<cr>:let v:searchforward=0<cr>
+  " Project-wide occurrences
+  command! -buffer -nargs=0 MerlinOccurrencesProjectWide call merlin#OccurrencesProjectWide()
 
   " Rename
   command! -buffer -nargs=* MerlinRename call merlin#OccurrencesRename(<f-args>)

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -81,7 +81,7 @@ endif
 let s:current_dir=expand("<sfile>:p:h")
 silent! MerlinPy import sys, vim
 MerlinPy if not vim.eval("s:current_dir") in sys.path:
-\    sys.path.append(vim.eval("s:current_dir"))
+\    sys.path.insert(0, vim.eval("s:current_dir"))
 
 MerlinPy import merlin
 


### PR DESCRIPTION
This adds the `:MerlinOccurrencesProjectWide` command, that is very similar to `:MerlinOccurrences` command but passes the `-scope project` flag and uses the quickfix list instead of the location list.

This is still work in progress, renames and incremental search and renames are not implemented.

Renames require reading files that might not be already open. The same trick
that was used to speed up reading preview text cannot be used for renames as a
Vim buffer is required to apply the change. This requires more work.
Incremental search and renames might also need a different implementation.

I'm unsure to which branch I should base this patch.
